### PR TITLE
Fix missing dependencies of building wheels

### DIFF
--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -44,6 +44,7 @@ jobs:
           pip install --upgrade pip
           git submodule update --init --recursive
           pip install -v .
+          pip install "setuptools>=64.0.0" "setuptools-scm>=8.0.0"
 
       - name: Build Source Distribution
         run: >-


### PR DESCRIPTION
This PR fixes the missing dependencies when running the `build` command.