### PR TITLE
Fix No module named 'docutils.utils.error_reporting' error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Documentation = "https://cugbasis.qcdevs.org/"
 # pip install qc-cugbasis[docs]
 docs = [
     "IPython",
-    "sphinx",
+    "sphinx>=7.0,<9.0",
     "sphinx-rtd-theme",
     "numpydoc",
     "sphinx_autodoc_typehints",


### PR DESCRIPTION
This pull request updates the documentation dependencies in `pyproject.toml` to specify a compatible version range for `sphinx`.

* Documentation dependencies: Updated the `sphinx` requirement to `sphinx>=7.0,<9.0` to ensure compatibility and prevent issues with future major releases.